### PR TITLE
Add bam-readcount, specify paths in fp filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,27 @@ RUN ln -s /opt/pindel-0.2.5b8/pindel2vcf /usr/bin/pindel2vcf
 
 COPY write_pindel_filter_config.pl /usr/bin/write_pindel_filter_config.pl
 
+###############
+#bam-readcount#
+###############
+RUN apt-get update && \
+    apt-get install -y \
+        cmake \
+        patch \
+        git
+
+ENV SAMTOOLS_ROOT=/opt/samtools
+RUN mkdir /opt/bam-readcount
+
+WORKDIR /opt/bam-readcount
+RUN git clone https://github.com/genome/bam-readcount.git /tmp/bam-readcount-0.7.4 && \
+    git -C /tmp/bam-readcount-0.7.4 checkout v0.7.4 && \
+    cmake /tmp/bam-readcount-0.7.4 && \
+    make && \
+    rm -rf /tmp/bam-readcount-0.7.4 && \
+    ln -s /opt/bam-readcount/bin/bam-readcount /usr/bin/bam-readcount
+
+
 ##########
 #fpfilter#
 ##########

--- a/fpfilter.pl
+++ b/fpfilter.pl
@@ -34,8 +34,8 @@ my $output_file;
 my $bam_file;
 my $bam_index;
 my $sample;
-my $bam_readcount_path = 'bam-readcount';
-my $samtools_path = 'samtools';
+my $bam_readcount_path = '/usr/bin/bam-readcount';
+my $samtools_path = '/opt/samtools/bin/samtools';
 my $ref_fasta;
 my $help;
 


### PR DESCRIPTION
The fp filter needs bam-readcount, so add it to the image.  Additionally use full paths to avoid samtools version conflicts.