### PR TITLE
The Javascript evaluation features of CWL require node.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ COPY split_interval_list_helper.pl /usr/bin/split_interval_list_helper.pl
 ######
 #Toil#
 ######
-RUN apt-get install -y python-pip python-dev build-essential
+RUN apt-get install -y python-pip python-dev build-essential nodejs
 RUN pip install --upgrade pip
 RUN pip install toil[cwl]
 RUN sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py


### PR DESCRIPTION
This is needed for `InlineJavascriptRequirement`s.