### PR TITLE
Install tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ RUN pip install toil[cwl]
 RUN sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
 
 
-RUN apt-get update -y && apt-get install -y libnss-sss
+RUN apt-get update -y && apt-get install -y libnss-sss tzdata
 RUN ln -sf /usr/share/zoneinfo/America/Chicago /etc/localtime
 
 #LSF: Java bug that need to change the /etc/timezone.


### PR DESCRIPTION
The current docker hub build is failing with

```
[91mdpkg-query: package 'tzdata' is not installed and no information is available
Use dpkg --info (= dpkg-deb --info) to examine archive files,
and dpkg --contents (= dpkg-deb --contents) to list their contents.
/usr/sbin/dpkg-reconfigure: tzdata is not installed
[0m
Removing intermediate container 24d116410485

The command '/bin/sh -c dpkg-reconfigure --frontend noninteractive tzdata' returned a non-zero code: 1
```

I hope that this will fix this error but I'm not sure that it will because I'm unable to reproduce the error locally.