### PR TITLE
Fix error caused by how VEP annotates structural variants

### DIFF
--- a/add_annotations_to_table_helper.py
+++ b/add_annotations_to_table_helper.py
@@ -44,6 +44,10 @@ def resolve_alleles(entry, csq_alleles):
         for alt in alts:
             if len(alt) > len(entry.REF) and 'insertion' in csq_alleles:
                 alleles[alt] = 'insertion'
+            elif len(alt) < len(entry.REF) and 'deletion' in csq_alleles:
+                alleles[alt] = 'deletion'
+            elif len(csq_alleles) == 1:
+                alleles[alt] = list(csq_alleles)[0]
     else:
         for alt in entry.ALT:
             alt = str(alt)


### PR DESCRIPTION
For structural variants, VEP will encode the alternate allele in the CSQ field as `deletion`, `insertion` or `RPL`. There might be others as well but I haven't encountered them and I haven't been able to find any documentation on this. We previously only handled SVs tagged as `insertion`. This PR adds `deletions` as well as a general case that should catch the remainder as well.