### PR TITLE
Update toil to 3.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,7 +297,7 @@ COPY split_interval_list_helper.pl /usr/bin/split_interval_list_helper.pl
 ######
 #Toil#
 ######
-RUN pip install toil[cwl]==3.6.0
+RUN pip install toil[cwl]==3.12.0
 RUN sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
 
 RUN apt-get update -y && apt-get install -y libnss-sss tzdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -298,7 +298,13 @@ COPY split_interval_list_helper.pl /usr/bin/split_interval_list_helper.pl
 #Toil#
 ######
 RUN pip install toil[cwl]==3.12.0
+RUN cd /tmp/ \
+    && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsfHelper.py \
+    && mv -f lsfHelper.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/ \
+    && wget --no-check-certificate https://raw.githubusercontent.com/tmooney/toil/3.12_lsf_fix/src/toil/batchSystems/lsf.py \
+    && mv -f lsf.py /usr/local/lib/python2.7/dist-packages/toil/batchSystems/
 RUN sed -i 's/select\[type==X86_64 && mem/select[mem/' /usr/local/lib/python2.7/dist-packages/toil/batchSystems/lsf.py
+
 
 RUN apt-get update -y && apt-get install -y libnss-sss tzdata
 RUN ln -sf /usr/share/zoneinfo/America/Chicago /etc/localtime


### PR DESCRIPTION
This is the same version change included in genome/docker-rnaseq#4 and should probably be released simultaneously with that and a new release of the `genome_perl_environment` test image.