### PR TITLE
New helper to only run commands on non-empty VCFs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -336,3 +336,9 @@ RUN rm -rf /tmp/verifyBamID /tmp/libStatGen
 RUN apt-get update && apt-get install -y r-base littler
 
 RUN apt-get install -y lib32ncurses5 
+
+###########
+#vcf_check#
+###########
+
+COPY vcf_check.pl /usr/bin/vcf_check.pl

--- a/vcf_check.pl
+++ b/vcf_check.pl
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use File::Copy qw(copy);
+
+
+if(@ARGV < 3) {
+    print STDERR "Usage: <VCF> <output destination if VCF empty> <command if VCF non-empty> [command args...]\n";
+    exit -1;
+}
+
+main(@ARGV);
+exit 0;
+
+sub main {
+    my ($vcf_to_check, $where_to_copy_if_empty, @commandline_if_nonempty) = @_;
+
+    if (vcf_is_empty($vcf_to_check)) {
+        copy($vcf_to_check, $where_to_copy_if_empty) or die('Failed to copy empty VCF: ' . $!);
+    } else {
+        exec { $commandline_if_nonempty[0] } @commandline_if_nonempty;
+        die('Failed to execute command: ' . $!);
+    }
+}
+
+
+sub vcf_is_empty {
+    my $vcf = shift;
+
+    my $is_compressed = $vcf =~ /\.gz$/;
+
+    my $cmd = $is_compressed? 'zgrep' : 'grep';
+
+    my $rv = system($cmd, '-q', '-v', '#', $vcf);
+
+    if ($rv == -1) {
+        die('Failed to execute command to inspect VCF: ' . $!);
+    }
+
+    #0 rv from grep indicates a match for a data line was found => non-empty
+    #1 rv from grep indicates only header lines were present => empty
+    #other return codes are bad.
+
+    $rv >>= 8;
+
+    if ($rv == 0 or $rv == 1) {
+        return $rv;
+    } else {
+        die('Failed to determine VCF status. Unexpected return code from grep: ' . $rv);
+    }
+}
+


### PR DESCRIPTION
Wrap a command with vcf_check.pl and it will copy the input to an output
location if the VCF contains no non-header lines.

Example:
```
vcf_check.pl potentially_empty.vcf output.vcf \
 fancy_processing_script_that_breaks_on_empty_vcfs.pl potentially_empty.vcf
```