### PR TITLE
Workaround for broken pipe error from `zgrep`.

### DIFF
--- a/vcf_check.pl
+++ b/vcf_check.pl
@@ -31,9 +31,13 @@ sub vcf_is_empty {
 
     my $is_compressed = $vcf =~ /\.gz$/;
 
-    my $cmd = $is_compressed? 'zgrep' : 'grep';
-
-    my $rv = system($cmd, '-q', '-v', '#', $vcf);
+    my $rv;
+    if ($is_compressed) {
+        #hack to get around broken pipe error from `zgrep`
+        $rv = system(q(zcat ') . $vcf . q(' 2>/dev/null | grep -q -v '#'));
+    } else {
+        $rv = system('grep', '-q', '-v', '#', $vcf);
+    }
 
     if ($rv == -1) {
         die('Failed to execute command to inspect VCF: ' . $!);


### PR DESCRIPTION
When run from within `cwltoil` using LSF, `zgrep` was exiting 2 with a broken pipe error.  This doesn't occur on the command-line, with `subprocess.Popen` in interactive python, when `bsub`bed, or with `cwltool`.

This change resorts to creating a subshell to ignore the return value of `zcat` after a broken pipe, since we want to return early without reading the whole VCF.