### PR TITLE
Add a signal handler for SIGPIPE so zgrep doesn't break.

### DIFF
--- a/vcf_check.pl
+++ b/vcf_check.pl
@@ -29,6 +29,8 @@ sub main {
 sub vcf_is_empty {
     my $vcf = shift;
 
+    local $SIG{PIPE} = sub { return 1; }; #prevent zgrep "broken pipe" errors
+
     my $is_compressed = $vcf =~ /\.gz$/;
 
     my $cmd = $is_compressed? 'zgrep' : 'grep';

--- a/vcf_check.pl
+++ b/vcf_check.pl
@@ -33,7 +33,7 @@ sub vcf_is_empty {
 
     my $is_compressed = $vcf =~ /\.gz$/;
 
-    my $cmd = $is_compressed? 'zgrep' : 'grep';
+    my $cmd = $is_compressed? '/bin/zgrep' : '/bin/grep';
 
     my $rv = system($cmd, '-q', '-v', '#', $vcf);
 

--- a/vcf_check.pl
+++ b/vcf_check.pl
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use File::Copy qw(copy);
+use IPC::Run qw(run);
 
 
 if(@ARGV < 3) {
@@ -18,7 +19,7 @@ sub main {
     my ($vcf_to_check, $where_to_copy_if_empty, @commandline_if_nonempty) = @_;
 
     if (vcf_is_empty($vcf_to_check)) {
-        copy($vcf_to_check, $where_to_copy_if_empty) or die('Failed to copy empty VCF: ' . $!);
+        copy_file($vcf_to_check, $where_to_copy_if_empty) or die('Failed to copy empty VCF: ' . $!);
     } else {
         exec { $commandline_if_nonempty[0] } @commandline_if_nonempty;
         die('Failed to execute command: ' . $!);
@@ -26,12 +27,18 @@ sub main {
 }
 
 
+sub is_compressed {
+    my $filename = shift;
+
+    return $filename =~ /\.gz$/;
+}
+
 sub vcf_is_empty {
     my $vcf = shift;
 
     local $SIG{PIPE} = sub { return 1; }; #prevent zgrep "broken pipe" errors
 
-    my $is_compressed = $vcf =~ /\.gz$/;
+    my $is_compressed = is_compressed($vcf);
 
     my $cmd = $is_compressed? '/bin/zgrep' : '/bin/grep';
 
@@ -53,4 +60,23 @@ sub vcf_is_empty {
         die('Failed to determine VCF status. Unexpected return code from grep: ' . $rv);
     }
 }
+
+sub copy_file {
+    my $source = shift;
+    my $dest = shift;
+
+    my $source_is_compressed = is_compressed($source);
+    my $dest_is_compressed = is_compressed($dest);
+
+    if ($source_is_compressed eq $dest_is_compressed) {
+        return copy($source, $dest);
+    } elsif ($source_is_compressed) {
+        return run(['/bin/gunzip', '-c', $source], '>', $dest);
+    } elsif ($dest_is_compressed) {
+        return run(['/bin/gzip', '-c', $source], '>', $dest);
+    } else {
+        die ('Logic error in copy_file.');
+    }
+}
+
 


### PR DESCRIPTION
This is an alternative to #68.  I like this better, since it doesn't resort to shell shenanigans.

Also, this fixes issues with `/gsc/bin/grep` being found in the path. (It doesn't work in `xenial`.)