### PR TITLE
Fix Docm bug

### DIFF
--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -5,7 +5,7 @@ use warnings;
 
 use feature qw(say);
 
-die("Wrong number of arguments. Provide docm_vcf, normal_sample_name, tumor_sample_name, output_dir") unless scalar(@ARGV) == 4;
+die("Wrong number of arguments. Provide docm_out_vcf, normal_cram, tumor_cram, output_dir") unless scalar(@ARGV) == 4;
 my ($docm_out_vcf, $normal_cram, $tumor_cram, $outdir) = @ARGV;
 
 my $samtools = '/opt/samtools/bin/samtools';

--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -5,13 +5,15 @@ use warnings;
 
 use feature qw(say);
 
-die("wrong number of arguments") unless scalar(@ARGV) == 2;
-my ($docm_out_vcf, $outdir) = @ARGV;
+die("Wrong number of arguments. Provide docm_vcf, normal_sample_name, tumor_sample_name, output_dir") unless scalar(@ARGV) == 4;
+my ($docm_out_vcf, $normal_name, $tumor_name, $outdir) = @ARGV;
 
 open(my $docm_vcf_fh, $docm_out_vcf)
     or die("couldn't open $docm_out_vcf to read");
 open(my $docm_filter_fh, ">", "$outdir/docm_filter_out.vcf")
     or die("couldn't open docm_filter_out.vcf for write");
+
+my ($normal_index, $tumor_index);
 
 while (<$docm_vcf_fh>) {
     chomp;
@@ -20,6 +22,14 @@ while (<$docm_vcf_fh>) {
     }
     elsif (/^#CHROM/) {
         my @columns = split /\t/, $_;
+        my %index = (
+            $columns[9]  => 9,
+            $columns[10] => 10,
+        );
+        ($normal_index, $tumor_index) = map{$index{$_}}($normal_name, $tumor_name);
+        unless ($normal_index and $tumor_index) {
+            die "Failed to get normal_index: $normal_index for $normal_name and tumor_index: $tumor_index for $tumor_name";
+        }
         $columns[9]  = 'NORMAL';
         $columns[10] = 'TUMOR';
         my $header = join "\t", @columns;
@@ -27,14 +37,17 @@ while (<$docm_vcf_fh>) {
     }
     else {
         my @columns = split /\t/, $_;
-        my @tumor_info = split /:/, $columns[10];
+        my @tumor_info = split /:/, $columns[$tumor_index];
         my ($AD, $DP) = ($tumor_info[1], $tumor_info[2]);
         next unless $AD;
         my @AD = split /,/, $AD;
         shift @AD; #the first one is ref count
         for my $ad (@AD) {
             if ($ad > 5 and $ad/$DP > 0.01) {
-                say $docm_filter_fh $_;
+                $columns[9]  = $columns[$normal_index];
+                $columns[10] = $columns[$tumor_index];
+                my $new_line = join "\t", @columns;
+                say $docm_filter_fh $new_line;
                 last;
             }
         }

--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -55,8 +55,9 @@ while (<$docm_vcf_fh>) {
         shift @AD; #the first one is ref count
         for my $ad (@AD) {
             if ($ad > 5 and $ad/$DP > 0.01) {
-                $columns[9]  = $columns[$normal_index];
-                $columns[10] = $columns[$tumor_index];
+                my ($normal_col, $tumor_col) = map{$columns[$_]}($normal_index, $tumor_index);
+                $columns[9]  = $normal_col;
+                $columns[10] = $tumor_col;
                 my $new_line = join "\t", @columns;
                 say $docm_filter_fh $new_line;
                 last;


### PR DESCRIPTION
GATK Haplotypecaller doesn't output NORMAL TUMOR column in fixed order consistently. Currently docm_filter.pl assumes TUMOR always on column 11, which is not always true.  Normal/tumor sample columns should always be parsed based on sample names in column headers.