### PR TITLE
adds pysam to install instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,6 +212,7 @@ COPY bam_readcount_helper.py /usr/bin/bam_readcount_helper.py
 COPY add_bam_readcount_to_vcf_helper.py /usr/bin/add_bam_readcount_to_vcf_helper.py
 
 RUN pip install cyvcf2
+RUN pip3 install pysam
 RUN pip3 install vcfpy
 
 ##########


### PR DESCRIPTION
I encountered error messages when running the [detect_variants.cwl pipeline](https://github.com/genome/cancer-genomics-workflow/tree/toil_compatibility/detect_variants). These seemed to indicate that the pysam module could not be found. This fixes the issue.