### PR TITLE
Add ignore_docm option

### DIFF
--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -5,8 +5,8 @@ use warnings;
 
 use feature qw(say);
 
-die("Wrong number of arguments. Provide docm_out_vcf, normal_cram, tumor_cram, output_vcf_file") unless scalar(@ARGV) == 4;
-my ($docm_out_vcf, $normal_cram, $tumor_cram, $outfile, $ignore_docm_flag) = @ARGV;
+die("Wrong number of arguments. Provide docm_out_vcf, normal_cram, tumor_cram, output_vcf_file, set_filter_flag") unless scalar(@ARGV) == 5;
+my ($docm_out_vcf, $normal_cram, $tumor_cram, $outfile, $set_filter_flag) = @ARGV;
 
 my $samtools = '/opt/samtools/bin/samtools';
 my $normal_header_str = `$samtools view -H $normal_cram`;
@@ -32,7 +32,7 @@ while (<$docm_vcf_fh>) {
         say $docm_filter_fh $_;
     }
     elsif (/^#CHROM/) {
-        if ($ignore_docm_flag) {
+        if ($set_filter_flag) {
             say $docm_filter_fh '##FILTER=<ID=DOCM_ONLY,Description="ignore Docm variants">';
         }
         my @columns = split /\t/, $_;
@@ -56,7 +56,7 @@ while (<$docm_vcf_fh>) {
         next unless $AD;
         my @AD = split /,/, $AD;
         shift @AD; #the first one is ref count
-        if ($ignore_docm_flag) {
+        if ($set_filter_flag) {
             $columns[6] = 'DOCM_ONLY';
         }
         for my $ad (@AD) {

--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -5,8 +5,8 @@ use warnings;
 
 use feature qw(say);
 
-die("Wrong number of arguments. Provide docm_out_vcf, normal_cram, tumor_cram, output_dir") unless scalar(@ARGV) == 4;
-my ($docm_out_vcf, $normal_cram, $tumor_cram, $outdir, $ignore_docm_flag) = @ARGV;
+die("Wrong number of arguments. Provide docm_out_vcf, normal_cram, tumor_cram, output_vcf_file") unless scalar(@ARGV) == 4;
+my ($docm_out_vcf, $normal_cram, $tumor_cram, $outfile, $ignore_docm_flag) = @ARGV;
 
 my $samtools = '/opt/samtools/bin/samtools';
 my $normal_header_str = `$samtools view -H $normal_cram`;
@@ -21,8 +21,8 @@ unless ($normal_name and $tumor_name) {
 
 open(my $docm_vcf_fh, $docm_out_vcf)
     or die("couldn't open $docm_out_vcf to read");
-open(my $docm_filter_fh, ">", "$outdir/docm_filter_out.vcf")
-    or die("couldn't open docm_filter_out.vcf for write");
+open(my $docm_filter_fh, ">", "$outfile")
+    or die("couldn't open $outfile for write");
 
 my ($normal_index, $tumor_index);
 

--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -33,7 +33,7 @@ while (<$docm_vcf_fh>) {
     }
     elsif (/^#CHROM/) {
         if ($ignore_docm_flag and $ignore_docm_flag eq 'ignoreDOCM') {
-            say $docm_filter_fh '##FILTER=<ID=IgnoreDOCM,Description="ignore Docm variants">';
+            say $docm_filter_fh '##FILTER=<ID=DOCM_ONLY,Description="ignore Docm variants">';
         }
         my @columns = split /\t/, $_;
         my %index = (
@@ -57,7 +57,7 @@ while (<$docm_vcf_fh>) {
         my @AD = split /,/, $AD;
         shift @AD; #the first one is ref count
         if ($ignore_docm_flag and $ignore_docm_flag eq 'ignoreDOCM') {
-            $columns[6] = 'IgnoreDOCM';
+            $columns[6] = 'DOCM_ONLY';
         }
         for my $ad (@AD) {
             if ($ad > 5 and $ad/$DP > 0.01) {

--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -32,7 +32,7 @@ while (<$docm_vcf_fh>) {
         say $docm_filter_fh $_;
     }
     elsif (/^#CHROM/) {
-        if ($ignore_docm_flag and $ignore_docm_flag eq "1") {
+        if ($ignore_docm_flag) {
             say $docm_filter_fh '##FILTER=<ID=DOCM_ONLY,Description="ignore Docm variants">';
         }
         my @columns = split /\t/, $_;
@@ -56,7 +56,7 @@ while (<$docm_vcf_fh>) {
         next unless $AD;
         my @AD = split /,/, $AD;
         shift @AD; #the first one is ref count
-        if ($ignore_docm_flag and $ignore_docm_flag eq 'ignoreDOCM') {
+        if ($ignore_docm_flag) {
             $columns[6] = 'DOCM_ONLY';
         }
         for my $ad (@AD) {

--- a/docm_filter.pl
+++ b/docm_filter.pl
@@ -32,7 +32,7 @@ while (<$docm_vcf_fh>) {
         say $docm_filter_fh $_;
     }
     elsif (/^#CHROM/) {
-        if ($ignore_docm_flag and $ignore_docm_flag eq 'ignoreDOCM') {
+        if ($ignore_docm_flag and $ignore_docm_flag eq "1") {
             say $docm_filter_fh '##FILTER=<ID=DOCM_ONLY,Description="ignore Docm variants">';
         }
         my @columns = split /\t/, $_;


### PR DESCRIPTION
For non-cle analysis, docm variants are not needed and this PR is to add ignore_docm option to docm_filter.pl to filter out all docm variants.