### PR TITLE
Add split_interval_list_to_bed_helper.pl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,7 +297,7 @@ RUN mkdir /opt/picard-2.18.1/ \
     && ln -s /opt/picard-2.18.1 /usr/picard
 
 COPY split_interval_list_helper.pl /usr/bin/split_interval_list_helper.pl
-
+COPY split_interval_list_to_bed_helper.pl /usr/bin/split_interval_list_to_bed_helper.pl
 
 ######
 #Toil#

--- a/split_interval_list_to_bed_helper.pl
+++ b/split_interval_list_to_bed_helper.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use feature qw(say);
+
+my $retval = system('/usr/bin/java', '-jar', '/usr/picard/picard.jar', 'IntervalListTools', @ARGV);
+exit $retval if $retval != 0;
+
+my $i = 1;
+for my $interval_list (glob('*/scattered.interval_list')) {
+    my $bed = $i.'.interval.bed';
+    open(my $in_fh, $interval_list) or die "fail to open $interval_list for read"; 
+    open(my $out_fh, ">$bed") or die "fail to write to $bed";
+    while (<$in_fh>) {
+        next if /^@/;
+        my ($chr, $start, $stop) = split /\t/, $_;
+        $out_fh->say(join("\t", $chr, $start-1, $stop));
+    }
+    close $in_fh;
+    close $out_fh;
+    $i++
+}


### PR DESCRIPTION
This script is to split interval_list to beds with equal number of bases, which will be used in reworked pindel sub workflow (https://github.com/genome/analysis-workflows/pull/700).  It is tested ok. @chrisamiller Can you review this ?